### PR TITLE
Check for Duplicates In Mining Mode

### DIFF
--- a/JL.Core/Config/CoreConfigManager.cs
+++ b/JL.Core/Config/CoreConfigManager.cs
@@ -15,6 +15,7 @@ public sealed class CoreConfigManager
     public bool AnkiIntegration { get; set; } // = false;
     public bool ForceSyncAnki { get; private set; } // = false;
     public bool AllowDuplicateCards { get; private set; } // = false;
+    public bool CheckForDuplicateCards { get; private set; } // = false;
     public double LookupRate { get; private set; } // = 0;
     public bool CaptureTextFromClipboard { get; set; } = true;
     public bool CaptureTextFromWebSocket { get; set; } // = false;
@@ -95,6 +96,7 @@ public sealed class CoreConfigManager
         AnkiIntegration = ConfigDBManager.GetValueFromConfig(connection, AnkiIntegration, nameof(AnkiIntegration), bool.TryParse);
         ForceSyncAnki = ConfigDBManager.GetValueFromConfig(connection, ForceSyncAnki, nameof(ForceSyncAnki), bool.TryParse);
         AllowDuplicateCards = ConfigDBManager.GetValueFromConfig(connection, AllowDuplicateCards, nameof(AllowDuplicateCards), bool.TryParse);
+        CheckForDuplicateCards = ConfigDBManager.GetValueFromConfig(connection, CheckForDuplicateCards, nameof(CheckForDuplicateCards), bool.TryParse);
         LookupRate = ConfigDBManager.GetNumberWithDecimalPointFromConfig(connection, LookupRate, nameof(LookupRate), double.TryParse);
         TextBoxTrimWhiteSpaceCharacters = ConfigDBManager.GetValueFromConfig(connection, TextBoxTrimWhiteSpaceCharacters, nameof(TextBoxTrimWhiteSpaceCharacters), bool.TryParse);
         TextBoxRemoveNewlines = ConfigDBManager.GetValueFromConfig(connection, TextBoxRemoveNewlines, nameof(TextBoxRemoveNewlines), bool.TryParse);

--- a/JL.Windows/ConfigManager.cs
+++ b/JL.Windows/ConfigManager.cs
@@ -848,6 +848,7 @@ internal sealed class ConfigManager
         preferenceWindow.WebSocketUriTextBox.Text = coreConfigManager.WebSocketUri.OriginalString;
         preferenceWindow.ForceSyncAnkiCheckBox.IsChecked = coreConfigManager.ForceSyncAnki;
         preferenceWindow.AllowDuplicateCardsCheckBox.IsChecked = coreConfigManager.AllowDuplicateCards;
+        preferenceWindow.CheckForDuplicateCardsCheckBox.IsChecked = coreConfigManager.CheckForDuplicateCards;
         preferenceWindow.LookupRateNumericUpDown.Value = coreConfigManager.LookupRate;
         preferenceWindow.KanjiModeCheckBox.IsChecked = coreConfigManager.KanjiMode;
         preferenceWindow.AutoAdjustFontSizesOnResolutionChange.IsChecked = AutoAdjustFontSizesOnResolutionChange;
@@ -1212,6 +1213,9 @@ internal sealed class ConfigManager
 
             ConfigDBManager.UpdateSetting(connection, nameof(CoreConfigManager.AllowDuplicateCards),
                 preferenceWindow.AllowDuplicateCardsCheckBox.IsChecked.ToString()!);
+
+            ConfigDBManager.UpdateSetting(connection, nameof(CoreConfigManager.CheckForDuplicateCards),
+                preferenceWindow.CheckForDuplicateCardsCheckBox.IsChecked.ToString()!);
 
             ConfigDBManager.UpdateSetting(connection, nameof(CoreConfigManager.LookupRate),
                 preferenceWindow.LookupRateNumericUpDown.Value.ToString(CultureInfo.InvariantCulture));

--- a/JL.Windows/GUI/PopupWindow.xaml.cs
+++ b/JL.Windows/GUI/PopupWindow.xaml.cs
@@ -700,7 +700,6 @@ internal sealed partial class PopupWindow
             {
                 if (MiningUtils.CheckDuplicate(result).Result)
                 {
-                    Utils.Frontend.Alert(AlertLevel.Error, $"{result.PrimarySpelling} is a duplicate card");
                     Button duplicate = new()
                     {
                         Name = nameof(duplicate),

--- a/JL.Windows/GUI/PopupWindow.xaml.cs
+++ b/JL.Windows/GUI/PopupWindow.xaml.cs
@@ -695,6 +695,31 @@ internal sealed partial class PopupWindow
             audioButton.Click += AudioButton_Click;
 
             _ = top.Children.Add(audioButton);
+
+            if (!configManager.MineToFileInsteadOfAnki)
+            {
+                if (MiningUtils.CheckDuplicate(result).Result)
+                {
+                    Utils.Frontend.Alert(AlertLevel.Error, $"{result.PrimarySpelling} is a duplicate card");
+                    Button duplicate = new()
+                    {
+                        Name = nameof(duplicate),
+                        Content = "⚠️",
+                        Foreground = configManager.DefinitionsColor,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        Margin = new Thickness(3, 0, 0, 0),
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        Background = Brushes.Transparent,
+                        Cursor = Cursors.Arrow,
+                        BorderThickness = new Thickness(0),
+                        Padding = new Thickness(0),
+                        FontSize = 14,
+                        ToolTip = $"{result.PrimarySpelling} is already in anki deck."
+                    };
+
+                    _ = top.Children.Add(duplicate);
+                }
+            }
         }
 
         if (result.AlternativeSpellings is not null && configManager.AlternativeSpellingsFontSize > 0)

--- a/JL.Windows/GUI/PreferencesWindow.xaml
+++ b/JL.Windows/GUI/PreferencesWindow.xaml
@@ -1033,6 +1033,13 @@
                                 <CheckBox x:Name="AllowDuplicateCardsCheckBox"  HorizontalAlignment="Right" />
                             </DockPanel>
 
+                            <DockPanel Margin="0,10,0,0">
+                                <TextBlock HorizontalAlignment="Left" Text="Check for duplicate cards"
+                                            Style="{StaticResource TextBlockDefault}" VerticalAlignment="Center" TextWrapping="Wrap"
+                                            ToolTip="Checks Anki for Duplicate Expressions when entering Mining Mode" Cursor="Help"/>
+                                <CheckBox x:Name="CheckForDuplicateCardsCheckBox"  HorizontalAlignment="Right" />
+                            </DockPanel>
+
                             <TabControl Margin="0,10,0,0">
                                 <TabControl.Resources>
                                     <Style TargetType="{x:Type TabPanel}">


### PR DESCRIPTION
closes https://github.com/rampaa/JL/issues/107.

Added a config (default false) for checking duplicates when entering mining mode.

This will check all the results in mining mode for an already existing expression in the configured anki deck, and display a warning next to the result if it finds one.

Creating this as a draft as I want to:
- Take another look at the method for checking duplicates. I assume it can be simplified quite a bit... I did, however, already try creating a method that would send everything to anki in one call, since "canAddNote" can receive multiple notes, but performance was markedly worse.
- Do some extensive testing on the overall performance impact of this with large dictionary(s) as requested. With just the default dictionaries it seems to be completely unnoticeable. 
