### PR TITLE
Add NameTextBox above MainTextBox

### DIFF
--- a/JL.Windows/ConfigManager.cs
+++ b/JL.Windows/ConfigManager.cs
@@ -73,6 +73,15 @@ internal sealed class ConfigManager
     public double MaxDelayBetweenCopiesForMergingMatchingSequentialTextsInMilliseconds { get; private set; } = 5000;
     public bool TextBoxUseCustomLineHeight { get; private set; } // = false;
     public double TextBoxCustomLineHeight { get; private set; } = 75;
+    //MINE defs
+    public bool ShowButton1 { get; private set; } = true;
+    public bool ShowButton2 { get; private set; } = true;
+    public bool ShowButton3 { get; private set; } // = false;
+    public bool NameTextBox_Use { get; private set; } = true;
+    public double NameTextBox_Height { get; private set; } = 56;
+    public double NameTextBox_MainTextBoxLeftOffset { get; private set; } = 34;
+    public double NameTextBox_MainTextBoxLeftOffset_WhenNoName { get; private set; } // = 0;
+    //MINEEND
     public bool RepositionMainWindowOnTextChangeByBottomPosition { get; private set; } // = false;
     public double MainWindowFixedBottomPosition { get; private set; } = -2;
     public bool RepositionMainWindowOnTextChangeByRightPosition { get; private set; } // = false;
@@ -421,6 +430,50 @@ internal sealed class ConfigManager
             mainWindow.MainTextBox.SetValue(TextBlock.LineHeightProperty, double.NaN);
         }
 
+        //MINE ApplyPreferences
+        ShowButton1 = ConfigDBManager.GetValueFromConfig(connection, ShowButton1, nameof(ShowButton1), bool.TryParse);
+        ShowButton2 = ConfigDBManager.GetValueFromConfig(connection, ShowButton2, nameof(ShowButton2), bool.TryParse);
+        ShowButton3 = ConfigDBManager.GetValueFromConfig(connection, ShowButton3, nameof(ShowButton3), bool.TryParse);
+#pragma warning disable format
+        mainWindow.OpacityButtonStackPanel.Visibility  = ShowButton1 ? Visibility.Visible : Visibility.Collapsed;
+        mainWindow.FontSizeButtonStackPanel.Visibility = ShowButton2 ? Visibility.Visible : Visibility.Collapsed;
+        mainWindow.ButtonHideStackPanel.Visibility     = ShowButton3 ? Visibility.Visible : Visibility.Collapsed;
+#pragma warning restore format
+
+        NameTextBox_Use = ConfigDBManager.GetValueFromConfig(connection, NameTextBox_Use, nameof(NameTextBox_Use), bool.TryParse);
+        NameTextBox_Height = ConfigDBManager.GetNumberWithDecimalPointFromConfig(connection, NameTextBox_Height, nameof(NameTextBox_Height), double.TryParse);
+        NameTextBox_MainTextBoxLeftOffset = ConfigDBManager.GetNumberWithDecimalPointFromConfig(
+            connection, NameTextBox_MainTextBoxLeftOffset, nameof(NameTextBox_MainTextBoxLeftOffset), double.TryParse
+            );
+        NameTextBox_MainTextBoxLeftOffset_WhenNoName = ConfigDBManager.GetNumberWithDecimalPointFromConfig(
+            connection, NameTextBox_MainTextBoxLeftOffset_WhenNoName, nameof(NameTextBox_MainTextBoxLeftOffset_WhenNoName), double.TryParse
+            );
+        //TODO: maybe add extra checks here? So negatives, numbers like 0.5, and numbers too large get normalized.
+        if (NameTextBox_Use)
+        {
+            mainWindow.NameTextBox.Visibility = Visibility.Visible;
+            Thickness th = mainWindow.MainTextBox.Margin;
+            if (mainWindow.NameTextBox.Text.Length == 0)
+            {
+                th.Left = 5 + NameTextBox_MainTextBoxLeftOffset_WhenNoName;
+            }
+            else
+            {
+                th.Left = 5 + NameTextBox_MainTextBoxLeftOffset;
+            }
+            th.Top = 30 + NameTextBox_Height;
+            mainWindow.MainTextBox.Margin = th;
+        }
+        else
+        {
+            mainWindow.NameTextBox.Visibility = Visibility.Collapsed;
+            Thickness th = mainWindow.MainTextBox.Margin;
+            th.Left = 5;
+            th.Top = 20;
+            mainWindow.MainTextBox.Margin = th;
+        }
+        //MINEEND
+
         AutoHidePopupIfMouseIsNotOverItDelayInMilliseconds = ConfigDBManager.GetNumberWithDecimalPointFromConfig(connection, AutoHidePopupIfMouseIsNotOverItDelayInMilliseconds, nameof(AutoHidePopupIfMouseIsNotOverItDelayInMilliseconds), double.TryParse);
         PopupWindowUtils.PopupAutoHideTimer.Enabled = false;
         PopupWindowUtils.PopupAutoHideTimer.Interval = AutoHidePopupIfMouseIsNotOverItDelayInMilliseconds;
@@ -631,6 +684,7 @@ internal sealed class ConfigManager
         {
             string mainWindowFontStr = ConfigDBManager.GetValueFromConfig(connection, "Meiryo", "MainWindowFont");
             mainWindow.MainTextBox.FontFamily = new FontFamily(mainWindowFontStr);
+            mainWindow.NameTextBox.FontFamily = new FontFamily(mainWindowFontStr);
         }
 
         {
@@ -949,6 +1003,14 @@ internal sealed class ConfigManager
         preferenceWindow.DictTypeFontSizeNumericUpDown.Value = DictTypeFontSize;
         preferenceWindow.MaxDelayBetweenCopiesForMergingMatchingSequentialTextsInMillisecondsNumericUpDown.Value = MaxDelayBetweenCopiesForMergingMatchingSequentialTextsInMilliseconds;
         preferenceWindow.TextBoxCustomLineHeightNumericUpDown.Value = TextBoxCustomLineHeight;
+        //MINE LoadPreferenceWindow
+        preferenceWindow.ShowButton1CheckBox.IsChecked = ShowButton1;
+        preferenceWindow.ShowButton2CheckBox.IsChecked = ShowButton2;
+        preferenceWindow.ShowButton3CheckBox.IsChecked = ShowButton3;
+        preferenceWindow.NameTextBox_Height_NumericUpDown.Value = NameTextBox_Height;
+        preferenceWindow.NameTextBox_MainTextBoxLeftOffset_NumericUpDown.Value = NameTextBox_MainTextBoxLeftOffset;
+        preferenceWindow.NameTextBox_MainTextBoxLeftOffset_WhenNoName_NumericUpDown.Value = NameTextBox_MainTextBoxLeftOffset_WhenNoName;
+        //MINEEND
         preferenceWindow.AutoHidePopupIfMouseIsNotOverItDelayInMillisecondsNumericUpDown.Value = AutoHidePopupIfMouseIsNotOverItDelayInMilliseconds;
         preferenceWindow.DefinitionsFontSizeNumericUpDown.Value = DefinitionsFontSize;
         preferenceWindow.FrequencyFontSizeNumericUpDown.Value = FrequencyFontSize;
@@ -1330,6 +1392,29 @@ internal sealed class ConfigManager
 
             ConfigDBManager.UpdateSetting(connection, nameof(TextBoxCustomLineHeight),
                 preferenceWindow.TextBoxCustomLineHeightNumericUpDown.Value.ToString(CultureInfo.InvariantCulture));
+
+            //MINE SavePreferences
+            ConfigDBManager.UpdateSetting(connection, nameof(ShowButton1),
+                preferenceWindow.ShowButton1CheckBox.IsChecked.ToString()!);
+
+            ConfigDBManager.UpdateSetting(connection, nameof(ShowButton2),
+                preferenceWindow.ShowButton2CheckBox.IsChecked.ToString()!);
+
+            ConfigDBManager.UpdateSetting(connection, nameof(ShowButton3),
+                preferenceWindow.ShowButton3CheckBox.IsChecked.ToString()!);
+
+            ConfigDBManager.UpdateSetting(connection, nameof(NameTextBox_Use),
+                preferenceWindow.NameTextBox_Use_Checkbox.IsChecked.ToString()!);
+
+            ConfigDBManager.UpdateSetting(connection, nameof(NameTextBox_Height),
+                preferenceWindow.NameTextBox_Height_NumericUpDown.Value.ToString(CultureInfo.InvariantCulture));
+
+            ConfigDBManager.UpdateSetting(connection, nameof(NameTextBox_MainTextBoxLeftOffset),
+                preferenceWindow.NameTextBox_MainTextBoxLeftOffset_NumericUpDown.Value.ToString(CultureInfo.InvariantCulture));
+
+            ConfigDBManager.UpdateSetting(connection, nameof(NameTextBox_MainTextBoxLeftOffset_WhenNoName),
+                preferenceWindow.NameTextBox_MainTextBoxLeftOffset_WhenNoName_NumericUpDown.Value.ToString(CultureInfo.InvariantCulture));
+            //MINEEND
 
             ConfigDBManager.UpdateSetting(connection, nameof(SeparatorColor), preferenceWindow.SeparatorColorButton.Tag.ToString()!);
 

--- a/JL.Windows/GUI/MainWindow.xaml
+++ b/JL.Windows/GUI/MainWindow.xaml
@@ -42,7 +42,12 @@
             </Rectangle.ContextMenu>
         </Rectangle>
 
-        <uc:TouchScreenTextBox x:Name="MainTextBox" Margin="5,20,5,5" TextWrapping="Wrap" VerticalContentAlignment="Top" HorizontalContentAlignment="Left" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+        <uc:TouchScreenTextBox x:Name="NameTextBox" Margin="5,30,5,5" VerticalContentAlignment="Top"
+                               Background="Transparent" Foreground="White" FontSize="32"
+                               IsReadOnly="True" BorderThickness="0,0,0,0" >
+        </uc:TouchScreenTextBox>
+
+        <uc:TouchScreenTextBox x:Name="MainTextBox" Margin="39,90,5,5" TextWrapping="Wrap" VerticalContentAlignment="Top" HorizontalContentAlignment="Left" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                  Background="Transparent" FontSize="{Binding Value, ElementName=FontSizeSlider}" 
                  IsReadOnly="True" BorderThickness="0,0,0,0" MouseMove="MainTextBox_MouseMove" TextBlock.LineHeight="Auto" TextBlock.LineStackingStrategy="MaxHeight"
                  VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" AutoWordSelection="False"
@@ -92,7 +97,7 @@
         </uc:TouchScreenTextBox>
 
         <DockPanel Margin="10,0,0,0" HorizontalAlignment="Left">
-            <StackPanel Width="20">
+            <StackPanel Width="20" x:Name="OpacityButtonStackPanel">
                 <TextBlock x:Name="OpacityButton" HorizontalAlignment="Center" MouseLeave="TitleBarButtonMouseLeave"
                    Text="☯" TextWrapping="Wrap" VerticalAlignment="Top" Foreground="White" FontFamily="Meiryo UI"
                    MouseDown="OpacityButton_MouseDown" ToolTip="Opacity" FontWeight="Normal" FontSize="18">
@@ -111,7 +116,7 @@
                 ScrollViewer.VerticalScrollBarVisibility="Disabled" LostFocus="OpacitySlider_LostFocus">
                 </Slider>
             </StackPanel>
-            <StackPanel Margin="5,0,0,0" Width="20">
+            <StackPanel Margin="5,0,0,0" Width="20" x:Name="FontSizeButtonStackPanel">
                 <TextBlock x:Name="FontSizeButton" HorizontalAlignment="Center" MouseLeave="TitleBarButtonMouseLeave"
                    Text="T" TextWrapping="Wrap" VerticalAlignment="Top" Foreground="White" FontFamily="Meiryo UI"
                    MouseDown="FontSizeButton_MouseDown" ToolTip="Font Size" FontSize="18">
@@ -129,6 +134,18 @@
                 IsMoveToPointEnabled="True" ScrollViewer.VerticalScrollBarVisibility="Disabled"
                 IsSnapToTickEnabled="True" LostFocus="FontSizeSlider_LostFocus">
                 </Slider>
+            </StackPanel>
+            <StackPanel Width="20" x:Name="ButtonHideStackPanel">
+                <TextBlock x:Name="ButtonHide" HorizontalAlignment="Center" MouseLeave="TitleBarButtonMouseLeave"
+                   Text="H" TextWrapping="Wrap" VerticalAlignment="Top" Foreground="White" FontFamily="Meiryo UI"
+                   MouseDown="ButtonHide_MouseDown" ToolTip="Opacity" FontWeight="Normal" FontSize="18">
+                    <TextBlock.Background>
+                        <SolidColorBrush Color="Black" Opacity="0.002"/>
+                    </TextBlock.Background>
+                    <TextBlock.Effect>
+                        <DropShadowEffect ShadowDepth="0.5" BlurRadius="3" Direction="320" Opacity="0.8" RenderingBias="Quality" />
+                    </TextBlock.Effect>
+                </TextBlock>
             </StackPanel>
         </DockPanel>
 

--- a/JL.Windows/GUI/MainWindow.xaml.cs
+++ b/JL.Windows/GUI/MainWindow.xaml.cs
@@ -159,6 +159,55 @@ internal sealed partial class MainWindow
             return false;
         }
 
+        int nameSplitPoint = 0;
+        string? name = null;
+        if (configManager.NameTextBox_Use)
+        {
+            {
+                int quoteEnd = sanitizedNewText.LastIndexOf('」');
+                if (quoteEnd == sanitizedNewText.Length - 1)
+                {
+                    int quoteStart = sanitizedNewText.IndexOf('「', StringComparison.Ordinal);
+                    if (quoteStart >= 0)
+                    {
+                        int i = quoteStart;
+                        nameSplitPoint = i;
+                    }
+                }
+            }
+
+            if (nameSplitPoint == 0)
+            {
+                int quoteEnd = sanitizedNewText.LastIndexOf('』');
+                if (quoteEnd == sanitizedNewText.Length - 1)
+                {
+                    int quoteStart = sanitizedNewText.IndexOf('『', StringComparison.Ordinal);
+                    if (quoteStart >= 0)
+                    {
+                        int i = quoteStart;
+                        nameSplitPoint = i;
+                    }
+                }
+            }
+
+
+            if (nameSplitPoint != 0)
+            {
+                int i = nameSplitPoint;
+                name = sanitizedNewText[..i];
+                //TODO: this is done again later, but I do this here to return false quickly.
+                // Probably not necessary. Check if necessary.
+                //TODO: would be nice to pass a number nameSplitPoint instead of string name,
+                // but that requires some changes down the line.
+
+                sanitizedNewText = sanitizedNewText[(i + 1)..];
+                if (sanitizedNewText.Length is 0)
+                {
+                    return false;
+                }
+            }
+        }
+
         bool mergeTexts = false;
         string? subsequentText = null;
         string? mergedText = null;
@@ -215,6 +264,25 @@ internal sealed partial class MainWindow
             else
             {
                 MainTextBox.Text = sanitizedNewText;
+            }
+
+            if (configManager.NameTextBox_Use)
+            {
+                if (nameSplitPoint != 0)
+                {
+                    //string name = sanitizedNewText[..nameSplitPoint];
+                    NameTextBox.Text = name;
+                    Thickness th = MainTextBox.Margin;
+                    th.Left = configManager.NameTextBox_MainTextBoxLeftOffset;
+                    MainTextBox.Margin = th;
+                }
+                else
+                {
+                    NameTextBox.Text = "";
+                    Thickness th = MainTextBox.Margin;
+                    th.Left = configManager.NameTextBox_MainTextBoxLeftOffset_WhenNoName;
+                    MainTextBox.Margin = th;
+                }
             }
 
             MainTextBox.Foreground = configManager.MainWindowTextColor;
@@ -403,6 +471,25 @@ internal sealed partial class MainWindow
         else if (e.ChangedButton is MouseButton.Right)
         {
             PopupWindowUtils.HidePopups(FirstPopupWindow);
+        }
+    }
+
+    private void ButtonHide_MouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton is MouseButton.Left)
+        {
+            if (Background.Opacity <= 0.02)
+            {
+                Background.Opacity = 0.2;
+                MainTextBox.Opacity = 1.0;
+                NameTextBox.Opacity = 1.0;
+            }
+            else
+            {
+                Background.Opacity = 0.01;
+                MainTextBox.Opacity = 0.01;
+                NameTextBox.Opacity = 0.01;
+            }
         }
     }
 

--- a/JL.Windows/GUI/PreferencesWindow.xaml
+++ b/JL.Windows/GUI/PreferencesWindow.xaml
@@ -618,6 +618,33 @@
                                               HorizontalAlignment="Right" />
                         </DockPanel>
 
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="Show Button 1"
+                                       TextWrapping="Wrap" VerticalAlignment="Center"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       Cursor="Help"
+                                       ToolTip="Show or hide button 1."/>
+                            <CheckBox x:Name="ShowButton1CheckBox" HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="Show Button 2"
+                                       TextWrapping="Wrap" VerticalAlignment="Center"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       Cursor="Help"
+                                       ToolTip="Show or hide button 2."/>
+                            <CheckBox x:Name="ShowButton2CheckBox" HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="Show Button 3"
+                                       TextWrapping="Wrap" VerticalAlignment="Center"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       Cursor="Help"
+                                       ToolTip="Show or hide button 3."/>
+                            <CheckBox x:Name="ShowButton3CheckBox" HorizontalAlignment="Right" />
+                        </DockPanel>
+
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>
@@ -991,6 +1018,48 @@
                             <Button x:Name="SeparatorColorButton"  HorizontalAlignment="Right"
                                     Width="60" BorderThickness="5,5,5,5"
                                     Height="32" BorderBrush="#FF707070" Click="ShowColorPicker" />
+                        </DockPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+            <TabItem Header="NameTextBox" HorizontalAlignment="Left" Width="100">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" PanningMode="Both">
+                    <StackPanel Margin="20,10,20,10">
+                        <StackPanel.Resources>
+                            <Style TargetType="{x:Type DockPanel}">
+                                <Setter Property="Margin" Value="0,10,0,0" />
+                            </Style>
+                        </StackPanel.Resources>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="Use NameTextBox"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       TextWrapping="Wrap" VerticalAlignment="Center" />
+                            <CheckBox x:Name="NameTextBox_Use_Checkbox"  HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="NameTextBox Height"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       TextWrapping="Wrap" VerticalAlignment="Center" />
+                            <hc:NumericUpDown x:Name="NameTextBox_Height_NumericUpDown" Minimum="0"
+                                            HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="MainTextBox left offset"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       TextWrapping="Wrap" VerticalAlignment="Center" />
+                            <hc:NumericUpDown x:Name="NameTextBox_MainTextBoxLeftOffset_NumericUpDown" Minimum="0"
+                                            HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <DockPanel>
+                            <TextBlock HorizontalAlignment="Left" Text="MainTextBox left offset (when no name is on screen)"
+                                       Style="{StaticResource TextBlockDefault}"
+                                       TextWrapping="Wrap" VerticalAlignment="Center" />
+                            <hc:NumericUpDown x:Name="NameTextBox_MainTextBoxLeftOffset_WhenNoName_NumericUpDown" Minimum="0"
+                                            HorizontalAlignment="Right" />
                         </DockPanel>
                     </StackPanel>
                 </ScrollViewer>


### PR DESCRIPTION
I made it so text in JL window matches exactly with the text in the game window, so I can put it on top of game text and read with my mouse.

This is how it looks like right now:

![screenshot fjsoeifjwighnsofj](https://github.com/user-attachments/assets/a163c45b-445d-4ee0-bbba-de7544ecc782)

It's a bit jank right now. And of course it doesn't see when text in game is drawn bigger or smaller than usual.

I added new preferences in Preferences->Main Window, on the very bottom, "Show Button 1", "Show Button 2", "Show Button 3". Third button is "H" button, and it "Hides" both most of the window and text. Popup still works though.

There is also Preferences->NameTextBox now, this is where you can enable NameTextBox.

BUGS:

*) Names don't get preserved in history.

*) Preferences->NameTextBox->Use NameTextBox keeps getting unchecked every time settings are opened.

*) Context menu doesn't work if you click on NameTextBox instead of MainTextBox.

*) Popup doesn't disappear if you move mouse from MainTextBox to NameTextBox. Move mouse down when you done reading.